### PR TITLE
AuthenticationScheme spec_uri is optional

### DIFF
--- a/scim2_models/rfc7643/service_provider_config.py
+++ b/scim2_models/rfc7643/service_provider_config.py
@@ -69,7 +69,7 @@ class AuthenticationScheme(ComplexAttribute):
     description: Annotated[str, Mutability.read_only, Required.true]
     """A description of the authentication scheme."""
 
-    spec_uri: Annotated[Optional[AnyUrl], Mutability.read_only]
+    spec_uri: Annotated[Optional[AnyUrl], Mutability.read_only] = None
     """An HTTP-addressable URL pointing to the authentication scheme's
     specification."""
 


### PR DESCRIPTION
I am getting a `ValidationError` when attempting to construct a `AuthenticationScheme` object without specifying `spec_uri`:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for AuthenticationScheme
specUri
  Field required [type=missing, input_value={'type': 'oauthbearertoke...n': 'HTTP Bearer Token'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
```