### PR TITLE
attributes are case insensitive

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Fixed
+^^^^^
+
+- Attributes are case insensitive #39
+
 [0.1.10] - 2024-06-30
 ---------------------
 

--- a/scim2_models/utils.py
+++ b/scim2_models/utils.py
@@ -1,5 +1,21 @@
+import re
 from typing import Optional
+
+from pydantic.alias_generators import to_snake
 
 
 def int_to_str(status: Optional[int]) -> Optional[str]:
     return None if status is None else str(status)
+
+
+def to_camel(string: str) -> str:
+    """Transform strings to camelCase.
+
+    This is more or less the pydantic implementation, but it does not
+    add uppercase on alphanumerical characters after specials
+    characters. For instance '$ref' stays '$ref'.
+    """
+
+    snake = to_snake(string)
+    camel = re.sub(r"_+([0-9A-Za-z]+)", lambda m: m.group(1).title(), snake)
+    return camel

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 from scim2_models import BulkRequest
 from scim2_models import BulkResponse
@@ -133,3 +134,32 @@ def test_everything_is_optional():
     ]
     for model in models:
         model()
+
+
+def test_case_sensitivity():
+    """RFC7643 §2.1 indicates that attribute names should be case insensitive.
+
+    Attribute names are case insensitive and are often "camel-cased"
+    (e.g., "camelCase").
+
+    Reported by issue #39.
+    """
+
+    payload = {
+        "UserName": "UserName123",
+        "Active": True,
+        "DisplayName": "BobIsAmazing",
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "externalId": uuid.uuid4().hex,
+        "name": {
+            "formatted": "Ryan Leenay",
+            "familyName": "Leenay",
+            "givenName": "Ryan",
+        },
+        "emails": [
+            {"Primary": True, "type": "work", "value": "testing@bob.com"},
+            {"Primary": False, "type": "home", "value": "testinghome@bob.com"},
+        ],
+    }
+    user = User.model_validate(payload)
+    assert user.display_name == "BobIsAmazing"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+from scim2_models.utils import to_camel
+
+
+def test_to_camel():
+    assert to_camel("foo") == "foo"
+    assert to_camel("Foo") == "foo"
+    assert to_camel("fooBar") == "fooBar"
+    assert to_camel("FooBar") == "fooBar"
+    assert to_camel("foo_bar") == "fooBar"
+    assert to_camel("Foo_bar") == "fooBar"
+    assert to_camel("foo_Bar") == "fooBar"
+    assert to_camel("Foo_Bar") == "fooBar"
+
+    assert to_camel("$foo$") == "$foo$"


### PR DESCRIPTION
RFC7643 §2.1 indicates that:

    Attribute names are case insensitive and are often "camel-cased" (e.g., "camelCase").

fixes #39 