### PR TITLE
Attributes of schema extensions can not be dumped

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Fixed
 ^^^^^
 - Additional bugfixes about attribute case sensitivity #45
+- Extension attributes dump were ignored #49
 - :class:`~scim2_models.ListResponse` tolerate any schema order #50
 
 [0.1.11] - 2024-07-02

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -240,9 +240,6 @@ Extensions attributes are accessed with brackets, e.g. ``user[EnterpriseUser].em
     ...     },
     ...     "userName": "bjensen@example.com",
     ...     "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
-    ...         "schemas": [
-    ...             "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
-    ...         ],
     ...         "employeeNumber": "701984",
     ...         "division": "Theme Park",
     ...     }


### PR DESCRIPTION
See test case. It was not possible to dump attributes of schema extensions. `scim_response_serializer` used `self.get_attribute_urn` to get the URN of `EnterpriseUser` (which results in `attribute_urn` to be `urn:ietf:params:scim:schemas:core:2.0:user:urn:ietf:params:scim:schemas:extension:enterprise:2.0:user`, probably also a bug), which does not get dumped.

This changes the code so that schema extensions are always returned. If no attributes from the extensions are requested, it still always returns a dict with `schemas` (which is expected).