### PR TITLE
EnterpriseUser manager should be a ComplexAttribute, not a MultiValuedComplexAttribute

### DIFF
--- a/scim2_models/rfc7643/enterprise_user.py
+++ b/scim2_models/rfc7643/enterprise_user.py
@@ -5,14 +5,14 @@ from typing import Optional
 
 from pydantic import Field
 
-from ..base import MultiValuedComplexAttribute
+from ..base import ComplexAttribute
 from ..base import Mutability
 from ..base import Reference
 from ..base import Required
 from .resource import Resource
 
 
-class Manager(MultiValuedComplexAttribute):
+class Manager(ComplexAttribute):
     value: Annotated[Optional[str], Required.true] = None
     """The id of the SCIM resource representing the User's manager."""
 


### PR DESCRIPTION
`EnterpriseUser` defines the `manager` attribute as a `MultiValuedComplexAttribute`.

https://github.com/yaal-coop/scim2-models/blob/0.1.14/scim2_models/rfc7643/enterprise_user.py#L15
```python
class Manager(MultiValuedComplexAttribute):
    value: Annotated[Optional[str], Required.true] = None
    """The id of the SCIM resource representing the User's manager."""

    ref: Annotated[Optional[Reference[ForwardRef("User")]], Required.true] = Field(
        None,
        serialization_alias="$ref",
    )
    """The URI of the SCIM resource representing the User's manager."""

    display_name: Annotated[Optional[str], Mutability.read_only] = None
    """The displayName of the User's manager."""
```

I believe this to be incorrect, and instead it should be a `ComplexAttribute` as per [RFC7643 Section 4.3](https://www.rfc-editor.org/rfc/rfc7643#section-4.3).

>    manager
>       The user's manager.  A complex type that optionally allows service
>       providers to represent organizational hierarchy by referencing the
>       "id" attribute of another User.

This is further backed up by the `/ResourceType` example in [RFC7643 Section 8.7.1](https://www.rfc-editor.org/rfc/rfc7643#section-8.7.1).

> ...
>       {
>         "name" : "manager",
>         "type" : "complex",
>         "multiValued" : false,
>         "description" : "The User's manager.  A complex type that
> optionally allows service providers to represent organizational
> hierarchy by referencing the 'id' attribute of another User.",
>         "required" : false,
> ...