### PR TITLE
external_id should be CaseExact.true

### DIFF
--- a/scim2_models/rfc7643/resource.py
+++ b/scim2_models/rfc7643/resource.py
@@ -169,9 +169,9 @@ class Resource(BaseModel, Generic[AnyExtension], metaclass=ResourceMetaclass):
     resource creation or replacement requests.
     """
 
-    external_id: Annotated[Optional[str], Mutability.read_write, Returned.default] = (
-        None
-    )
+    external_id: Annotated[
+        Optional[str], Mutability.read_write, Returned.default, CaseExact.true
+    ] = None
     """A String that is an identifier for the resource as defined by the
     provisioning client."""
 


### PR DESCRIPTION
See [RFC7643, Section 3.1](https://datatracker.ietf.org/doc/html/rfc7643#section-3.1)

> This attribute has "caseExact" as "true" and a mutability of "readWrite". This attribute is OPTIONAL.