### PR TITLE
fix: SearchRequest 'attributes' and 'excluded_attributes' are mutually exclusive.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[0.2.3] - Unreleased
+--------------------
+
+Changed
+^^^^^^^
+- :attr:`SearchRequest.attributes <scim2_models.SearchRequest.attributes>` and :attr:`SearchRequest.attributes <scim2_models.SearchRequest.excluded_attributes>` are mutually exclusive. #19
+
 [0.2.2] - 2024-09-20
 --------------------
 
@@ -15,7 +22,6 @@ Fixed
 Fixed
 ^^^^^
 - :attr:`~scim2_models.Resource.external_id` is :data:`scim2_models.CaseExact.true`. #74
-
 
 [0.2.0] - 2024-08-18
 --------------------

--- a/scim2_models/rfc7644/search_request.py
+++ b/scim2_models/rfc7644/search_request.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Optional
 
 from pydantic import field_validator
+from pydantic import model_validator
 
 from .message import Message
 
@@ -64,3 +65,12 @@ class SearchRequest(Message):
         """
 
         return None if value is None else max(1, value)
+
+    @model_validator(mode="after")
+    def attributes_validator(self):
+        if self.attributes and self.excluded_attributes:
+            raise ValueError(
+                "'attributes' and 'excluded_attributes' are mutually exclusive"
+            )
+
+        return self


### PR DESCRIPTION
   Clients MAY request a partial resource representation on any
   operation that returns a resource within the response by specifying
   either of the mutually exclusive URL query parameters "attributes" or
   "excludedAttributes", as follows:

https://datatracker.ietf.org/doc/html/rfc7644#section-3.9

fixes #19 