### PR TITLE
schema ids must be URIs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Added
 Changed
 ^^^^^^^
 - :attr:`SearchRequest.attributes <scim2_models.SearchRequest.attributes>` and :attr:`SearchRequest.attributes <scim2_models.SearchRequest.excluded_attributes>` are mutually exclusive. #19
+- :class:`~scim2_models.Schema` ids must be valid URIs. #26
 
 [0.2.2] - 2024-09-20
 --------------------

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from scim2_models import Attribute
 from scim2_models import Mutability
 from scim2_models import Returned
@@ -72,3 +75,14 @@ def test_group_schema(load_sample):
     )
 
     assert obj.model_dump(exclude_unset=True) == payload
+
+
+def test_uri_ids():
+    """Test that schema ids are URI, as defined in RFC7643 §7.
+
+    https://datatracker.ietf.org/doc/html/rfc7643#section-7
+    """
+
+    Schema(id="urn:ietf:params:scim:schemas:extension:enterprise:2.0:User")
+    with pytest.raises(ValidationError):
+        Schema(id="invalid\nuri")


### PR DESCRIPTION
as defined by RFC763 §7

   id
      The unique URI of the schema.  When applicable, service providers
      MUST specify the URI, e.g.,
      "urn:ietf:params:scim:schemas:core:2.0:User".  Unlike most other
      schemas, which use some sort of Globally Unique Identifier (GUID)
      for the "id", the schema "id" is a URI so that it can be
      registered and is portable between different service providers and
      clients.  REQUIRED.

fix #26